### PR TITLE
Fix BLEU score calculation by adjusting input format

### DIFF
--- a/notebook/C5 系统评估与优化/C5.ipynb
+++ b/notebook/C5 系统评估与优化/C5.ipynb
@@ -689,7 +689,7 @@
     "    # print(true_answers)\n",
     "    generate_answers = list(jieba.cut(generate_answer))\n",
     "    # print(generate_answers)\n",
-    "    bleu_score = sentence_bleu(true_answers, generate_answers)\n",
+    "    bleu_score = sentence_bleu([true_answers], generate_answers)\n",
     "    return bleu_score"
    ]
   },


### PR DESCRIPTION
最初的计算方式`bleu_score = sentence_bleu(true_answers, generate_answers)`
格式有误，应该为`bleu_score = sentence_bleu([true_answers], generate_answers)`
这个错误导致和`true_answer`完全一致的`answer1`得分趋近于0
