### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=datawhalechina/llm-universe&type=Date)](https://star-history.com/#datawhalechina/llm-universe&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=datawhalechina/llm-universe&type=Date)](https://star-history.dera.page/#datawhalechina/llm-universe&Date)

--- a/docs/README.md
+++ b/docs/README.md
@@ -170,5 +170,5 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=datawhalechina/llm-universe&type=Date)](https://star-history.com/#datawhalechina/llm-universe&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=datawhalechina/llm-universe&type=Date)](https://star-history.dera.page/#datawhalechina/llm-universe&Date)
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This fixes it by pointing to a working star history service so the chart displays correctly again.